### PR TITLE
fix: examples/及びsample/のファイルにおけるcatch_exceptions引数の欠落、catch_exceptions引数の意図しない指定、silentの指定方法を修正

### DIFF
--- a/examples/api_req.rs
+++ b/examples/api_req.rs
@@ -38,6 +38,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         false,
         false,
         vec![],
+        false,
     );
 
     let api = "http://api.openweathermap.org/data/2.5/weather";

--- a/examples/progress_logging.rs
+++ b/examples/progress_logging.rs
@@ -1,4 +1,4 @@
-use versalogrs::NewVersaLog;
+use versalogrs::{VersaLog, NewVersaLog};
 
 fn process_file(log: &VersaLog, index: usize, total: usize) {
     log.Step(
@@ -28,11 +28,16 @@ fn process_file(log: &VersaLog, index: usize, total: usize) {
 }
 
 fn main() {
-    let log = VersaLog::new(
+    let log = NewVersaLog(
         "detailed",
         true,
         true,
         "BATCH",
+        false,
+        false,
+        false,
+        vec![],
+        false,
     );
 
     log.Info("Batch Start", &[]);

--- a/sample/detailed_test.rs
+++ b/sample/detailed_test.rs
@@ -11,6 +11,7 @@ fn main() {
         false,
         false,
         vec![],
+        false,
     );
 
     logger.Info("info", &[]);
@@ -31,6 +32,7 @@ fn main() {
         false,
         false,
         vec![],
+        false,
     );
 
     logger.Info("info", &[]);
@@ -51,6 +53,7 @@ fn main() {
         false,
         false,
         vec![],
+        false,
     );
 
     logger.Info("info", &[]);
@@ -71,6 +74,7 @@ fn main() {
         false,
         false,
         vec![],
+        false,
     );
 
     logger.Info("info", &[]);
@@ -91,6 +95,7 @@ fn main() {
         false,
         false,
         vec![],
+        false,
     );
 
     logger.Info("info", &[]);
@@ -111,6 +116,7 @@ fn main() {
         true,
         false,
         vec![],
+        false,
     );
 
     logger.Info("info", &[]);
@@ -120,7 +126,7 @@ fn main() {
     logger.Critical("critical", &[]);
 }
 
-// silent false
+// catch_exceptions false
 fn main() {
     let logger = NewVersaLog(
         "detailed",
@@ -133,6 +139,49 @@ fn main() {
         vec![],
         false,
     );
+
+    logger.Info("info", &[]);
+    logger.Error("error", &[]);
+    logger.Warning("warning.", &[]);
+    logger.Debug("debug", &[]);
+    logger.Critical("critical", &[]);
+}
+
+// catch_exceptions true
+fn main() {
+    let logger = NewVersaLog(
+        "detailed",
+        false,
+        false,
+        "VersaLog",
+        false,
+        false,
+        false,
+        vec![],
+        true,
+    );
+
+    logger.Info("info", &[]);
+    logger.Error("error", &[]);
+    logger.Warning("warning.", &[]);
+    logger.Debug("debug", &[]);
+    logger.Critical("critical", &[]);
+}
+
+// silent false
+fn main() {
+    let mut logger = NewVersaLog(
+        "detailed",
+        false,
+        false,
+        "VersaLog",
+        false,
+        false,
+        false,
+        vec![],
+        false,
+    );
+    logger.set_silent(false);
 
     logger.Info("info", &[]);
     logger.Error("info", &[]);
@@ -152,9 +201,10 @@ fn main() {
         false,
         true,
         vec![],
-        true,
+        false,
     );
-
+    logger.set_silent(true);
+    
     logger.Info("info", &[]);
     logger.Error("info", &[]);
     logger.Warning("warning.", &[]);
@@ -173,6 +223,7 @@ fn main() {
         false,
         false,
         vec![],
+        false,
     );
 
     logger.Info("info", &[]);

--- a/sample/file_test.rs
+++ b/sample/file_test.rs
@@ -10,6 +10,7 @@ fn main() {
         false,
         false,
         vec![],
+        false,
     );
 
     logger.Info("info", &[]);

--- a/sample/log_save_test.rs
+++ b/sample/log_save_test.rs
@@ -10,6 +10,7 @@ fn main() {
         false,
         true,
         vec![],
+        false,
     );
 
     logger.Info("info", &[]);

--- a/sample/simple2_test.rs
+++ b/sample/simple2_test.rs
@@ -11,6 +11,7 @@ fn main() {
         false,
         false,
         vec![],
+        false,
     );
 
     logger.Info("info", &[]);
@@ -31,6 +32,7 @@ fn main() {
         false,
         false,
         vec![],
+        false,
     );
 
     logger.Info("info", &[]);
@@ -51,6 +53,7 @@ fn main() {
         false,
         false,
         vec![],
+        false,
     );
 
     logger.Info("info", &[]);
@@ -71,6 +74,7 @@ fn main() {
         false,
         false,
         vec![],
+        false,
     );
 
     logger.Info("info", &[]);
@@ -91,6 +95,7 @@ fn main() {
         false,
         false,
         vec![],
+        false,
     );
 
     logger.Info("info", &[]);
@@ -111,6 +116,49 @@ fn main() {
         true,
         false,
         vec![],
+        false,
+    );
+
+    logger.Info("info", &[]);
+    logger.Error("error", &[]);
+    logger.Warning("warning.", &[]);
+    logger.Debug("debug", &[]);
+    logger.Critical("critical", &[]);
+}
+
+// catch_exception false
+fn main() {
+    let logger = NewVersaLog(
+        "simple2",
+        false,
+        false,
+        "VersaLog",
+        false,
+        false,
+        false,
+        vec![],
+        false,
+    );
+
+    logger.Info("info", &[]);
+    logger.Error("error", &[]);
+    logger.Warning("warning.", &[]);
+    logger.Debug("debug", &[]);
+    logger.Critical("critical", &[]);
+}
+
+// catch_exception true
+fn main() {
+    let logger = NewVersaLog(
+        "simple2",
+        false,
+        false,
+        "VersaLog",
+        false,
+        false,
+        false,
+        vec![],
+        false,
     );
 
     logger.Info("info", &[]);
@@ -122,7 +170,7 @@ fn main() {
 
 // silent false
 fn main() {
-    let logger = NewVersaLog(
+    let mut logger = NewVersaLog(
         "simple2",
         false,
         false,
@@ -133,6 +181,7 @@ fn main() {
         vec![],
         false,
     );
+    logger.set_silent(false);
 
     logger.Info("info", &[]);
     logger.Error("info", &[]);
@@ -143,7 +192,7 @@ fn main() {
 
 // silent true
 fn main() {
-    let logger = NewVersaLog(
+    let mut logger = NewVersaLog(
         "simple2",
         false,
         false,
@@ -152,8 +201,9 @@ fn main() {
         false,
         true,
         vec![],
-        true,
+        false,
     );
+    logger.set_silent(true);
 
     logger.Info("info", &[]);
     logger.Error("info", &[]);
@@ -173,6 +223,7 @@ fn main() {
         false,
         false,
         vec![],
+        false,
     );
 
     logger.Info("info", &[]);

--- a/sample/simple_test.rs
+++ b/sample/simple_test.rs
@@ -11,6 +11,7 @@ fn main() {
         false,
         false,
         vec![],
+        false,
     );
 
     logger.Info("info", &[]);
@@ -31,6 +32,7 @@ fn main() {
         false,
         false,
         vec![],
+        false,
     );
 
     logger.Info("info", &[]);
@@ -51,6 +53,7 @@ fn main() {
         false,
         false,
         vec![],
+        false,
     );
 
     logger.Info("info", &[]);
@@ -71,6 +74,7 @@ fn main() {
         false,
         false,
         vec![],
+        false,
     );
 
     logger.Info("info", &[]);
@@ -91,6 +95,7 @@ fn main() {
         false,
         false,
         vec![],
+        false,
     );
 
     logger.Info("info", &[]);
@@ -111,6 +116,7 @@ fn main() {
         true,
         false,
         vec![],
+        false,
     );
 
     logger.Info("info", &[]);
@@ -120,7 +126,7 @@ fn main() {
     logger.Critical("critical", &[]);
 }
 
-// silent false
+// catch_exception false
 fn main() {
     let logger = NewVersaLog(
         "simple",
@@ -133,6 +139,49 @@ fn main() {
         vec![],
         false,
     );
+
+    logger.Info("info", &[]);
+    logger.Error("error", &[]);
+    logger.Warning("warning.", &[]);
+    logger.Debug("debug", &[]);
+    logger.Critical("critical", &[]);
+}
+
+// catch_exception true
+fn main() {
+    let logger = NewVersaLog(
+        "simple",
+        false,
+        false,
+        "VersaLog",
+        false,
+        false,
+        false,
+        vec![],
+        true,
+    );
+
+    logger.Info("info", &[]);
+    logger.Error("error", &[]);
+    logger.Warning("warning.", &[]);
+    logger.Debug("debug", &[]);
+    logger.Critical("critical", &[]);
+}
+
+// silent false
+fn main() {
+    let mut logger = NewVersaLog(
+        "simple",
+        false,
+        false,
+        "VersaLog",
+        false,
+        false,
+        false,
+        vec![],
+        false,
+    );
+    logger.set_silent(false);
 
     logger.Info("info", &[]);
     logger.Error("info", &[]);
@@ -152,8 +201,9 @@ fn main() {
         false,
         true,
         vec![],
-        true,
+        false,
     );
+    logger.set_silent(true);
 
     logger.Info("info", &[]);
     logger.Error("info", &[]);
@@ -173,6 +223,7 @@ fn main() {
         false,
         false,
         vec![],
+        false,
     );
 
     logger.Info("info", &[]);

--- a/sample/simple_test.rs
+++ b/sample/simple_test.rs
@@ -126,7 +126,7 @@ fn main() {
     logger.Critical("critical", &[]);
 }
 
-// catch_exception false
+// catch_exceptions false
 fn main() {
     let logger = NewVersaLog(
         "simple",
@@ -147,7 +147,7 @@ fn main() {
     logger.Critical("critical", &[]);
 }
 
-// catch_exception true
+// catch_exceptions true
 fn main() {
     let logger = NewVersaLog(
         "simple",


### PR DESCRIPTION
- catch_exceptionsにfalseを渡すように修正
- catch_exceptions false及びcatch_exceptions trueの例を追加

Closes #27 